### PR TITLE
SSL support

### DIFF
--- a/c_src/cb.h
+++ b/c_src/cb.h
@@ -9,6 +9,7 @@ typedef struct connect_args {
     char* user;
     char* pass;
     char* bucket;
+    char* cert;
 } connect_args_t;
 
 typedef struct store_args {

--- a/src/cberl.erl
+++ b/src/cberl.erl
@@ -6,7 +6,7 @@
 -vsn("1.0.5").
 -include("cberl.hrl").
 
--export([start_link/2, start_link/3, start_link/5, start_link/6, start_link/7]).
+-export([start_link/2, start_link/3, start_link/5, start_link/6, start_link/7, start_link/8]).
 -export([stop/1]).
 %% store operations
 -export([add/4, add/5, replace/4, replace/5, set/4, set/5, store/7]).
@@ -50,19 +50,24 @@ start_link(PoolName, NumCon, Host, Username, Password) ->
 %% @end
 %% @equiv start_link(PoolName, NumCon, Host, Username, Password, cberl_transcoder)
 start_link(PoolName, NumCon, Host, Username, Password, BucketName) ->
-    start_link(PoolName, NumCon, Host, Username, Password, BucketName, cberl_transcoder).
+    start_link(PoolName, NumCon, Host, Username, Password, BucketName, "", cberl_transcoder).
 
--spec start_link(atom(), integer(), string(), string(), string(), string(), atom()) -> {ok, pid()} | {error, _}.
-start_link(PoolName, NumCon, Host, Username, Password, BucketName, Transcoder) ->
+start_link(PoolName, NumCon, Host, Username, Password, BucketName, Certificate) ->
+    start_link(PoolName, NumCon, Host, Username, Password, BucketName, Certificate, cberl_transcoder).
+
+
+-spec start_link(atom(), integer(), string(), string(), string(), string(), string(), atom()) -> {ok, pid()} | {error, _}.
+start_link(PoolName, NumCon, Host, Username, Password, BucketName, Certificate, Transcoder) ->
     SizeArgs = [{size, NumCon},
                 {max_overflow, 0}],
     PoolArgs = [{name, {local, PoolName}},
                 {worker_module, cberl_worker}] ++ SizeArgs,
     WorkerArgs = [{host, Host},
-		  {username, Username},
-		  {password, Password},
-		  {bucketname, BucketName},
-		  {transcoder, Transcoder}],
+                  {username, Username},
+                  {password, Password},
+                  {bucketname, BucketName},
+                  {transcoder, Transcoder},
+                  {cert, Certificate}],
     poolboy:start_link(PoolArgs, WorkerArgs).
 
 stop(PoolPid) ->

--- a/src/cberl_worker.erl
+++ b/src/cberl_worker.erl
@@ -44,18 +44,18 @@ start_link(Args) ->
 %% @end
 %%--------------------------------------------------------------------
 init([{host, Host}, {username, Username}, {password, Password},
-      {bucketname, BucketName}, {transcoder, Transcoder}]) ->
+      {bucketname, BucketName}, {transcoder, Transcoder}, {cert, Certificate}]) ->
     process_flag(trap_exit, true),
     {ok, Handle} = cberl_nif:new(),
     State = #instance{handle = Handle,
                       transcoder = Transcoder,
                       bucketname = canonical_bucket_name(BucketName),
-                      opts = [Host, Username, Password, BucketName],
+                      opts = [Host, Username, Password, BucketName, Certificate],
                       connected = false},
     State2 = case connect(State) of
-        ok -> State#instance{connected = true};
-        {error, _} -> State#instance{connected = false}
-    end,
+                 ok -> State#instance{connected = true};
+                 {error, _} -> State#instance{connected = false}
+             end,
     {ok, State2}.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Add support for SSL connections to Couchbase server.
Simply add another parameter to start_link to use it:

`cberl:start_link(PoolName, NumCon, Host, Username, Password, BucketName, Certificate)`

Where `Certificate` holds the path to a local copy of the Root Certificate of the Couchbase server in PEM format eg:

```
-----BEGIN CERTIFICATE-----
AAU5NTjCCAeqgAwIBAgIIFMIVlVFsAU5NTJKoZIHELLOELBQAwJdd5+kKGA1UE
AxMZQ291Y2hiYXNlIFNlcdd5+kKMjYwNDkyZDAeFFRIENDAw2U5NTwMDBaFw00
OTEyMzEyMzU5NTlaMCQxIjAHELLOgNVBAMTGUNvdWNoYZSBTZXJ2ZXIgNjI2MDQ5
MmQU5NTMA0GCSqGSIb3DQEBAU5NTAFRIENDwdd5+kKBAQCxQakouIU1ABaZLFfv
Nk2hx3bL22Wau+kfyN5tItFy6iEeR61IXsCoMcK9xHELLOVZTwVwjL9bYV4BK7nTS
WWUWY+8q2xTaYCuFRIENDxZdd5+kKXqCLx0RpHOuAhsdbur+M9QbT6q+JiFUibP3B
J956dd5+kK6LN1fEw4+q8sbHELLOJbiQuMfkmk6YqJj/1FQb0U5NT2Z5zF4wMj5O+
lEyxwnuOqj+AUxU5NTziWEc4vJRoOz9zBFRIENDWjWsg794Pv9c/YOX0kWVxr
S6GtQ3Jdd5+kKOnNw0+KD50HELLO9jHU5NTSpaexKJ6KdQyCy2vn8c/3uHVmRPFQfPl
ztU/AgMBAAGjOEE2MA4GA1UdFRIENDAwICpDATBg76LEDDAKBggrBgEFBQcD
ATAPBgHELLOMBAf8EU5NTDAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAOUxnsvsSJQLJx
oVLqvfVxsXBvcI5iQFRIENDaPaTfd+5YzLKHWWVdf4Dp20Z1sMuKOovhNLHD0
r43Jjidd5+kKyF3CBtH0U5NTWc5rj8sbKHHELLO2aRoF3n8JLVbNf/NWwIL/D2
B74kQ3892XXtssjxVb42GMtRDgoIFRIENDFESWOtoBdd5+kKqv9MN0/P3b2dVA6
Ricy4t/tS89qEc/KEJS0lWHELLOHjbw8wh/nhU5NTcOnJDf0Hpnzdd5+kK3ZsLBzLzyc+
r//VWC6mB47tAqU5NThtMEStYkvYfnFRIENDOvxwbCU/GiuNMHuoeBkwNtC1ZR
yF3CBtH0U
-----END CERTIFICATE-----
```
The Root Certificate can be found on the Couchbase interface under `Security - Root Certificate`. If `Certificate` parameter is empty no SSL connection will be established.

If no SSL connection is possible, please check if your installed libcouchbase support SSL connections!